### PR TITLE
Added nested SVG. Major rework of `ctx`, it is no longer a `Celestine…

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A full list is [here](/dev_docs/svg_element_checklist.md).
 
 First, all drawing is done through `Celestine.draw` this returns a string SVG element, or works on an `IO`. You can easily embed this into webpages for dynamic server side drawing of assets.
 
-`Celestine.draw` takes a block which takes a `Celestine::Meta::Context` (or `ctx` in the examples), the basis of all DSL calls in Celestine.
+`Celestine.draw` takes a block which takes a `Celestine::Svg` (or `ctx` in the examples), the basis of all DSL calls in Celestine.
 
 ```crystal
 Celestine.draw do |ctx|
@@ -66,19 +66,63 @@ end
 
 All context methods such as `rectangle` or `circle` take a block that takes their respective types, and needs to have an object of that type returned.
 
-A short list of the Celestine types that can be used by `Celestine::Meta::Context` and their DSL methods
+A short list of the Celestine types that can be used by `Celestine::Svg` and their DSL methods
 
- * [Celestine::Rectangle](https://docs.celestine.dev/Celestine/Rectangle.html) -> [rectangle](https://docs.celestine.dev/Celestine/Meta/Context.html#rectangle(define=false,&block:Celestine::Rectangle-%3ECelestine::Rectangle):Celestine::Rectangle-instance-method)
- * [Celestine::Circle](https://docs.celestine.dev/Celestine/Circle.html) -> [circle](https://docs.celestine.dev/Celestine/Meta/Context.html#circle(define=false,&block:Celestine::Circle-%3ECelestine::Circle):Celestine::Circle-instance-method)
- * [Celestine::Ellipse](https://docs.celestine.dev/Celestine/Ellipse.html) -> [ellipse](https://docs.celestine.dev/Celestine/Meta/Context.html#ellipse(define=false,&block:Celestine::Ellipse-%3ECelestine::Ellipse):Celestine::Ellipse-instance-method)
- * [Celestine::Path](https://docs.celestine.dev/Celestine/Path.html) -> [path](https://docs.celestine.dev/Celestine/Meta/Context.html#path(define=false,&block:Celestine::Path-%3ECelestine::Path):Celestine::Path-instance-method)
- * [Celestine::Marker](https://docs.celestine.dev/Celestine/Marker.html) -> [marker](https://docs.celestine.dev/Celestine/Meta/Context.html#marker(&block:Celestine::Marker-%3ECelestine::Marker)-instance-method)
- * [Celestine::Mask](https://docs.celestine.dev/Celestine/Mask.html) -> [mask](https://docs.celestine.dev/Celestine/Meta/Context.html#mask(&block:Celestine::Mask-%3ECelestine::Mask)-instance-method)
- * [Celestine::Text](https://docs.celestine.dev/Celestine/Text.html) -> [text](https://docs.celestine.dev/Celestine/Meta/Context.html#text(define=false,&block:Celestine::Text-%3ECelestine::Text):Celestine::Text-instance-method)
- * [Celestine::Group](https://docs.celestine.dev/Celestine/Group.html) -> [group](https://docs.celestine.dev/Celestine/Meta/Context.html#group(define=false,&block:Celestine::Group-%3ECelestine::Group):Celestine::Group-instance-method)
- * [Celestine::Image](https://docs.celestine.dev/Celestine/Image.html) -> [image](https://docs.celestine.dev/Celestine/Meta/Context.html#image(define=false,&block:Celestine::Image-%3ECelestine::Image):Celestine::Image-instance-method)
- * [Celestine::Use](https://docs.celestine.dev/Celestine/Use.html) -> [use](https://docs.celestine.dev/Celestine/Meta/Context/Methods.html#use(id:String)-instance-method)
- * [Celestine::Filter](https://docs.celestine.dev/Celestine/Filter.html) -> [filter](https://docs.celestine.dev/Celestine/Meta/Context.html#filter(&block:Celestine::Filter-%3ECelestine::Filter)-instance-method)
+ * [Celestine::Anchor](https://docs.celestine.dev/Celestine/Anchor.html) -> [anchor](https://docs.celestine.dev/Celestine/Svg.html#anchor(define=false,&block:Celestine::Anchor-%3ECelestine::Anchor):Celestine::Anchor-instance-method)
+ * [Celestine::Circle](https://docs.celestine.dev/Celestine/Circle.html) -> [circle](https://docs.celestine.dev/Celestine/Svg.html#circle(define=false,&block:Celestine::Circle-%3ECelestine::Circle):Celestine::Circle-instance-method)
+ * [Celestine::Ellipse](https://docs.celestine.dev/Celestine/Ellipse.html) -> [ellipse](https://docs.celestine.dev/Celestine/Svg.html#ellipse(define=false,&block:Celestine::Ellipse->Celestine::Ellipse):Celestine::Ellipse-instance-method)
+ * [Celestine::Filter](https://docs.celestine.dev/Celestine/Filter.html) -> [filter](https://docs.celestine.dev/Celestine/Svg.html#filter(&block:Celestine::Filter->Celestine::Filter)-instance-method)
+ * [Celestine::Group](https://docs.celestine.dev/Celestine/Group.html) -> [group](https://docs.celestine.dev/Celestine/Svg.html#group(define=false,&block:Celestine::Group->Celestine::Group):Celestine::Group-instance-method)
+ * [Celestine::Image](https://docs.celestine.dev/Celestine/Image.html) -> [image](https://docs.celestine.dev/Celestine/Svg.html#image(define=false,&block:Celestine::Image->Celestine::Image):Celestine::Image-instance-method)
+ * [Celestine::Marker](https://docs.celestine.dev/Celestine/Marker.html) -> [marker](https://docs.celestine.dev/Celestine/Svg.html#marker(&block:Celestine::Marker->Celestine::Marker)-instance-method)
+ * [Celestine::Mask](https://docs.celestine.dev/Celestine/Mask.html) -> [mask](https://docs.celestine.dev/Celestine/Svg.html#mask(&block:Celestine::Mask->Celestine::Mask)-instance-method)
+ * [Celestine::Path](https://docs.celestine.dev/Celestine/Path.html) -> [path](https://docs.celestine.dev/Celestine/Svg.html#path(define=false,&block:Celestine::Path->Celestine::Path):Celestine::Path-instance-method)
+ * [Celestine::Rectangle](https://docs.celestine.dev/Celestine/Rectangle.html) -> [rectangle](https://docs.celestine.dev/Celestine/Svg.html#rectangle(define=false,&block:Celestine::Rectangle->Celestine::Rectangle):Celestine::Rectangle-instance-method)
+ * [Celestine::Svg](https://docs.celestine.dev/Celestine/Svg.html) -> [svg](https://docs.celestine.dev/Celestine/Svg.html#svg(define=false,&block:Celestine::Svg->Celestine::Svg):Celestine::Svg-instance-method)
+ * [Celestine::Text](https://docs.celestine.dev/Celestine/Text.html) -> [text](https://docs.celestine.dev/Celestine/Svg.html#text(define=false,&block:Celestine::Text->Celestine::Text):Celestine::Text-instance-method)
+
+ 
+### Nested SVG
+
+`Celestine::SVG` allows you to nest SVG.
+
+```crystal
+Celestine.draw do |ctx|
+  ctx.svg do |svg_doc2|
+    svg_doc2.rectangle do |r|
+      r
+    end
+
+    svg_doc2.circle do |c|
+      c
+    end
+
+    svg_doc2
+  end
+end
+```
+
+### Groups
+
+`Celestine::Group` allows you to group multiple elements under one parent. You can manipulate the `x`, `y`, and other attributes to apply them to the whole group, or just use it to combine elements easier.
+
+```crystal
+Celestine.draw do |ctx|
+  ctx.group do |g|
+    g.rectangle do |r|
+      r
+    end
+
+    g.circle do |c|
+      c
+    end
+
+    g
+  end
+end
+```
+
+Groups cannot `define` objects like `Celestine::Svg` can. Groups also cannot use the `mask`, `filter`, or `marker` DSL methods as they `define` in the SVG document.
 
 ### Use
 `Celestine::Use` can be used to save space in an SVG, and reuse certain elements without the need to copy the entire object into your SVG document.
@@ -87,11 +131,11 @@ The only caveat is that the `use` SVG element cannot change attributes it both d
 
 `Celestine::Use` also requires that the drawable it is copying has an `id` set. If not `Celestine::Use` will still let you reference an ID that doesn't exist if you run `use` with a string `id`.
 
-You can do this only with `Celestine::Meta::Context` (or `ctx` in the examples). `Celestine::Group`, `Celestine::Mask`, `Celestine::Marker` cannot define drawables.
+You can do this only with `Celestine::Svg` (or `ctx` in the examples). `Celestine::Group`, `Celestine::Mask`, `Celestine::Marker` cannot define drawables. The `use` element will only copy elements in the current SVG document you are in, so if you nest SVG inside SVG you need to be wary of how you define objects.
 
 ```crystal
 Celestine.draw do |ctx|
-  # Only `Celestine::Meta::Context` is allowed to "define" objects.
+  # Only `Celestine::Svg` is allowed to "define" objects.
   ctx.rectangle(define: true) do |r|
     # Set r's x, y, width, height and other attributes here
     r.id = "our-rect" # YOU MUST SET AN ID TO BE ABLE TO REUSE A COMPONENT, OR THERE IS NO WAY TO REFERENCE IT.

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: celestine
-version: 0.7.0alpha
+version: 0.7.1alpha
 
 authors:
   - Ian Rash <ian@sol.vin>

--- a/spec/celestine_spec.cr
+++ b/spec/celestine_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 module Celestine::Test
-  BLANK_SVG = %Q[<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg"></svg>]
+  BLANK_SVG = "<svg xmlns=\"http://www.w3.org/2000/svg\"  />"
   SVG_TAGS_SIMPLE = {
     "rectangle" => "rect",
     "circle" => "circle",
@@ -9,7 +9,8 @@ module Celestine::Test
     "path" => "path",
     "group" => "g",
     "image" => "image",
-    "text" => "text"
+    "text" => "text",
+    "anchor" => "a"
   }
 
   UNITS = %w[px em rem ch vh vw in cm mm pt pc ex % vmin vmax]

--- a/spec/common_drawables_spec.cr
+++ b/spec/common_drawables_spec.cr
@@ -1,4 +1,5 @@
 {% for drawable_class in Celestine::Meta::CLASSES %}
+{% if drawable_class.id != Celestine::Svg %}
 describe {{drawable_class.id}} do
   it "should add custom attributes" do
     celestine_svg = Celestine.draw do |ctx| 
@@ -11,7 +12,6 @@ describe {{drawable_class.id}} do
     if svg_root = parser.nodes(:svg).first
       svg_root.children.size.should eq(1)
       if child_element = svg_root.child
-        child_element.attributes.size.should eq(1)
         child_element.attribute_by("test-attr").should eq("Hello!")
       else
         raise "No child element found"
@@ -257,4 +257,5 @@ describe {{drawable_class.id}} do
   {% end %}
 
 end
+{% end %}
 {% end %}

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -10,7 +10,7 @@ end
 # Creates a test that runs different types of numbers through an attribute and then parses and searches for it. It also makes sure it is the only attribute,
 # as well as it only has one child element, the `{{drawable_class.id}}`
 macro make_number_attribute_test(drawable_class, attr_name_html, attr_name_cr, units = false)
-  it "should set attribute {{attr_name_html.id}} via {{attr_name_cr.id}} and there should be no other attributes set" do
+  it "should set attribute {{attr_name_html.id}} via {{attr_name_cr.id}}" do
     positive_values = [0, 1.0, 2, 4, 0.22, 99.0, 60000.0, 99999.9999]
     values = positive_values.clone
     positive_values.each { |v| values << -v }
@@ -30,7 +30,6 @@ macro make_number_attribute_test(drawable_class, attr_name_html, attr_name_cr, u
       if svg_root = parser.nodes(:svg).first
         svg_root.children.size.should eq(1)
         if child_element = svg_root.child
-          child_element.attributes.size.should eq(1)
           (child_element.attribute_by({{attr_name_html}}) == v.to_s).should eq(true)
         end
       end
@@ -51,7 +50,6 @@ macro make_number_attribute_test(drawable_class, attr_name_html, attr_name_cr, u
         if svg_root = parser.nodes(:svg).first
           svg_root.children.size.should eq(1)
           if child_element = svg_root.child
-            child_element.attributes.size.should eq(1)
             (child_element.attribute_by({{attr_name_html}}) == "#{v}#{unit}").should eq(true)
           end
         end
@@ -75,7 +73,6 @@ macro make_color_attribute_test(drawable_class, attr_name_html, attr_name_cr)
       if svg_root = parser.nodes(:svg).first
         svg_root.children.size.should eq(1)
         if child_element = svg_root.child
-          child_element.attributes.size.should eq(1)
           (child_element.attribute_by({{attr_name_html}}) == v.to_s).should eq(true)
         end
       end

--- a/src/drawables/svg.cr
+++ b/src/drawables/svg.cr
@@ -1,0 +1,63 @@
+# Draws and holds information for SVG images
+# 
+# * [Mozilla SVG Docs](https://developer.mozilla.org/en-US/docs/Web/SVG/Element/svg)
+class Celestine::Svg < Celestine::Drawable
+  alias ViewBox = NamedTuple(x: IFNumber, y: IFNumber, w: IFNumber, h: IFNumber)
+
+  TAG = "svg"
+
+  include_options Celestine::Modules::Body
+  include_options Celestine::Modules::StrokeFill
+  include_options Celestine::Modules::Transform
+  include_options Celestine::Modules::Mask
+  include_options Celestine::Modules::Filter
+
+  # Do not allow these to add their ATTRS since they are their own elements
+  include Celestine::Modules::Animate
+  include Celestine::Modules::Animate::Motion
+  include Celestine::Modules::Animate::Transform
+
+  @objects_io = IO::Memory.new
+  @defines_io = IO::Memory.new
+
+  property view_box : ViewBox?
+  property shape_rendering : String?
+
+  def initialize
+  end
+
+  # Draws this rectangle to an `IO`
+  def draw(io : IO) : Nil
+    io << %Q[<#{TAG} ]
+    io << %Q[xmlns="http://www.w3.org/2000/svg" ]
+
+    if self.view_box
+      vb = self.view_box.as(ViewBox)
+      io << %Q[viewBox="#{vb[:x]} #{vb[:y]} #{vb[:w]} #{vb[:h]}" ]
+    end
+
+    if self.shape_rendering
+      io << %Q[shape-rendering="#{shape_rendering}" ]
+    end
+
+    draw_attributes(io)
+
+    
+    if !@defines_io.empty? || !@objects_io.empty? || !inner_elements.empty?
+      io << %Q[>]
+      if !@defines_io.empty?
+        io << %Q[<defs>]
+        io << @defines_io
+        io << %Q[</defs>]
+      end
+      io << @objects_io
+      io << inner_elements
+      io << %Q[</#{TAG}>]
+    else
+      io << %Q[/>]
+    end
+  end
+
+  module Attrs
+  end
+end

--- a/src/effects/marker.cr
+++ b/src/effects/marker.cr
@@ -15,7 +15,7 @@ class Celestine::Marker < Celestine::Drawable
   property preserve_aspect_ratio : String?
   property ref_x : String?
   property ref_y : String?
-  property view_box : Celestine::Meta::Context::ViewBox?
+  property view_box : Celestine::Svg::ViewBox?
 
   @objects_io = IO::Memory.new
 
@@ -30,7 +30,7 @@ class Celestine::Marker < Celestine::Drawable
     io << %Q[#{Attrs::REF_X}="#{ref_x}" ] if ref_x
     io << %Q[#{Attrs::REF_Y}="#{ref_y}" ] if ref_y
     if @view_box
-      vb = @view_box.as(Celestine::Meta::Context::ViewBox)
+      vb = @view_box.as(Celestine::Svg::ViewBox)
       io << %Q[#{Attrs::VIEW_BOX}="#{vb[:x]} #{vb[:y]} #{vb[:w]} #{vb[:h]}"]
     end
     inner_elements << @objects_io


### PR DESCRIPTION
Added nested SVG. Major rework of `ctx`, it is no longer a `Celestine::Meta::Context` and is now a `Celestine::Svg` which is now a drawable.