### PR TITLE
require all files from animation/transform

### DIFF
--- a/src/celestine.cr
+++ b/src/celestine.cr
@@ -20,7 +20,7 @@ require "./drawables/image"
 
 require "./effects/animation/animate"
 require "./effects/animation/animate_motion"
-require "./effects/animation/transform/rotate"
+require "./effects/animation/transform/*"
 
 require "./effects/mask"
 require "./effects/filter"


### PR DESCRIPTION
src/celestine.cr didn't require all files from src/effects/animate/transform, so animateTransform functionality was broken. This should fix that (sorry for all the PRs, I need to test these things beforehand '^^)
